### PR TITLE
Remove test output

### DIFF
--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1029,7 +1029,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = ceilf((gcode->millimeters_of_travel / arc_segment));
+    uint16_t segments = ceilf(gcode->millimeters_of_travel / arc_segment);
 
   //printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1031,7 +1031,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
     // Figure out how many segments for this gcode
     uint16_t segments = ceilf((gcode->millimeters_of_travel / arc_segment));
 
-    printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
+  //printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;
     float linear_per_segment = linear_travel / segments;
 

--- a/src/modules/robot/Robot.cpp
+++ b/src/modules/robot/Robot.cpp
@@ -1029,7 +1029,7 @@ bool Robot::append_arc(Gcode * gcode, const float target[], const float offset[]
         }
     }
     // Figure out how many segments for this gcode
-    uint16_t segments = floorf((gcode->millimeters_of_travel / arc_segment)+1);
+    uint16_t segments = ceilf((gcode->millimeters_of_travel / arc_segment));
 
     printf("Radius %f - Segment Length %f - Number of Segments %d\r\n",radius,arc_segment,segments);  // Testing Purposes ONLY   
     float theta_per_segment = angular_travel / segments;


### PR DESCRIPTION
Testing successful, Commenting out test output to com port, leaving it in place in case anyone else wants to test it.

This also makes a correction to the formula on like 1032 which will prevent it from ever being zero, it also produces more accurate results since the defined variables are maximums, this assures the error is never greater than specified or the line segments are never longer than specified.