### PR TITLE
G28.1 minor refinement

### DIFF
--- a/src/modules/tools/endstops/Endstops.cpp
+++ b/src/modules/tools/endstops/Endstops.cpp
@@ -559,7 +559,7 @@ void Endstops::process_home_command(Gcode* gcode)
         // saves current position in absolute machine coordinates
         THEROBOT->get_axis_position(saved_position); // Only XY are used
         // Note the following is only meant to be used for recovering a saved position from config-override
-        // Not a standard Gcode and notto be relied on
+        // Not a standard Gcode and not to be relied on
         if (gcode->has_letter('X')) saved_position[X_AXIS] = gcode->get_value('X');
         if (gcode->has_letter('Y')) saved_position[Y_AXIS] = gcode->get_value('Y');
         return;
@@ -789,7 +789,7 @@ void Endstops::on_gcode_received(void *argument)
                     gcode->stream->printf(";Max Z\nM665 Z%1.3f\n", this->homing_position[2]);
                 }
                 if(saved_position[X_AXIS] != 0 || saved_position[Y_AXIS] != 0) {
-                    gcode->stream->printf(";predefined position:\nG28.1 X%1.4f Y%1.4f Z%1.4f\n", saved_position[X_AXIS], saved_position[Y_AXIS], saved_position[Z_AXIS]);
+                    gcode->stream->printf(";predefined position:\nG28.1 X%1.4f Y%1.4f\n", saved_position[X_AXIS], saved_position[Y_AXIS]);
                 }
                 break;
 


### PR DESCRIPTION
Only X and Y are used to move to predefined position with G28.2 (or G28
in GRBL mode), so Z should not be saved in the config-override file.
